### PR TITLE
Incluindo Result<T, MarvelError> como resultado da requisições

### DIFF
--- a/Marvel.xcodeproj/project.pbxproj
+++ b/Marvel.xcodeproj/project.pbxproj
@@ -49,9 +49,9 @@
 		159E393224D0EBE000744AB4 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 159E393424D0EBE000744AB4 /* Localizable.strings */; };
 		159E393824D0ECDF00744AB4 /* R+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159E393724D0ECDF00744AB4 /* R+Extensions.swift */; };
 		15AC48B224DAF0A400037F13 /* CharacterListViewControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AC48B124DAF0A400037F13 /* CharacterListViewControllerMock.swift */; };
-		15AC48B424DAF3A600037F13 /* CharacterListWorkerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AC48B324DAF3A600037F13 /* CharacterListWorkerMock.swift */; };
+		15AC48B424DAF3A600037F13 /* CharacterWorkerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AC48B324DAF3A600037F13 /* CharacterWorkerMock.swift */; };
 		15AC48B624DAF48700037F13 /* CharacterListBuilderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AC48B524DAF48700037F13 /* CharacterListBuilderMock.swift */; };
-		15AC48C024DB494800037F13 /* ComicBookListWorkerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AC48BF24DB494800037F13 /* ComicBookListWorkerMock.swift */; };
+		15AC48C024DB494800037F13 /* ComicBookWorkerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AC48BF24DB494800037F13 /* ComicBookWorkerMock.swift */; };
 		15AC48C524DB4FC200037F13 /* CharacterDetailsViewControllerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AC48C424DB4FC200037F13 /* CharacterDetailsViewControllerMock.swift */; };
 		15AC48C724DB50A900037F13 /* CharacterDetailsBuilderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AC48C624DB50A900037F13 /* CharacterDetailsBuilderMock.swift */; };
 		15AC48C924DB52E200037F13 /* CharacterDetailsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AC48C824DB52E200037F13 /* CharacterDetailsSpec.swift */; };
@@ -154,9 +154,9 @@
 		159E393524D0EBF500744AB4 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		159E393724D0ECDF00744AB4 /* R+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "R+Extensions.swift"; sourceTree = "<group>"; };
 		15AC48B124DAF0A400037F13 /* CharacterListViewControllerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterListViewControllerMock.swift; sourceTree = "<group>"; };
-		15AC48B324DAF3A600037F13 /* CharacterListWorkerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterListWorkerMock.swift; sourceTree = "<group>"; };
+		15AC48B324DAF3A600037F13 /* CharacterWorkerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterWorkerMock.swift; sourceTree = "<group>"; };
 		15AC48B524DAF48700037F13 /* CharacterListBuilderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterListBuilderMock.swift; sourceTree = "<group>"; };
-		15AC48BF24DB494800037F13 /* ComicBookListWorkerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComicBookListWorkerMock.swift; sourceTree = "<group>"; };
+		15AC48BF24DB494800037F13 /* ComicBookWorkerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComicBookWorkerMock.swift; sourceTree = "<group>"; };
 		15AC48C424DB4FC200037F13 /* CharacterDetailsViewControllerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterDetailsViewControllerMock.swift; sourceTree = "<group>"; };
 		15AC48C624DB50A900037F13 /* CharacterDetailsBuilderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterDetailsBuilderMock.swift; sourceTree = "<group>"; };
 		15AC48C824DB52E200037F13 /* CharacterDetailsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterDetailsSpec.swift; sourceTree = "<group>"; };
@@ -511,7 +511,7 @@
 			children = (
 				15E0221125D1D9CB00EA8350 /* CharacterList.json */,
 				15E0222825D201C800EA8350 /* CharacterSearch.json */,
-				15AC48B324DAF3A600037F13 /* CharacterListWorkerMock.swift */,
+				15AC48B324DAF3A600037F13 /* CharacterWorkerMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -528,7 +528,7 @@
 			isa = PBXGroup;
 			children = (
 				15E0223325D21E7C00EA8350 /* ComicBookList.json */,
-				15AC48BF24DB494800037F13 /* ComicBookListWorkerMock.swift */,
+				15AC48BF24DB494800037F13 /* ComicBookWorkerMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -1074,8 +1074,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				15AC48B424DAF3A600037F13 /* CharacterListWorkerMock.swift in Sources */,
-				15AC48C024DB494800037F13 /* ComicBookListWorkerMock.swift in Sources */,
+				15AC48B424DAF3A600037F13 /* CharacterWorkerMock.swift in Sources */,
+				15AC48C024DB494800037F13 /* ComicBookWorkerMock.swift in Sources */,
 				15AC48B224DAF0A400037F13 /* CharacterListViewControllerMock.swift in Sources */,
 				15AC48C724DB50A900037F13 /* CharacterDetailsBuilderMock.swift in Sources */,
 				15B6EA1624D0D641005F2CD2 /* CharacterLisSpec.swift in Sources */,

--- a/Marvel/Source/Features/CharacterDetails/CharacterDetailsInteractor.swift
+++ b/Marvel/Source/Features/CharacterDetails/CharacterDetailsInteractor.swift
@@ -70,13 +70,15 @@ class CharacterDetailsInteractor: CharacterDetailsInteractorProtocol, CharacterD
         
         comickBookListWorker.fetchComicBookList(
             character: character.id,
-            sucess: { [weak self] response in
-                self?.didFetchComicBookList(response)
-                self?.presenter.stopComicsLoading()
-            },
-            failure: { [weak self] error in
-                self?.presenter.showCharacterDetailsError(error)
-                self?.presenter.stopComicsLoading()
+            completation: { [weak self] result in
+                switch result {
+                case .success(let response):
+                    self?.didFetchComicBookList(response)
+                    self?.presenter.stopComicsLoading()
+                case .failure(let error):
+                    self?.presenter.showCharacterDetailsError(error)
+                    self?.presenter.stopComicsLoading()
+                }
             })
     }
     

--- a/Marvel/Source/Features/CharacterDetails/CharacterDetailsInteractor.swift
+++ b/Marvel/Source/Features/CharacterDetails/CharacterDetailsInteractor.swift
@@ -68,7 +68,7 @@ class CharacterDetailsInteractor: CharacterDetailsInteractorProtocol, CharacterD
     private func fetchComicBookList() {
         presenter.startComicsLoading()
         
-        comickBookListWorker.fetchComicBookList(
+        comickBookListWorker.fetchList(
             character: character.id,
             completation: { [weak self] result in
                 switch result {

--- a/Marvel/Source/Features/CharacterList/CharacterListInteractor.swift
+++ b/Marvel/Source/Features/CharacterList/CharacterListInteractor.swift
@@ -146,11 +146,13 @@ class CharacterListInteractor: CharacterListInteractorProtocol {
     private func fetchCharacters() {
         characterWorker.fetchCharacterList(
             offset: currentPage * pageCount,
-            sucess: { [weak self] response in
-                self?.didFetchCharacters(response)
-            },
-            failure: { [weak self] error in
-                self?.presenter.showCharacterListError(error)
+            completation: { [weak self] result in
+                switch result {
+                case .success(let response):
+                    self?.didFetchCharacters(response)
+                case .failure(let error):
+                    self?.presenter.showCharacterListError(error)
+                }
             })
     }
     
@@ -158,11 +160,13 @@ class CharacterListInteractor: CharacterListInteractorProtocol {
         characterWorker.fetchCharacterList(
             searchText: searchText,
             offset: currentPage * pageCount,
-            sucess: { [weak self] response in
-                self?.didFetchCharacters(response)
-            },
-            failure: { [weak self] error in
-                self?.presenter.showCharacterListError(error)
+            completation: { [weak self] result in
+                switch result {
+                case .success(let response):
+                    self?.didFetchCharacters(response)
+                case .failure(let error):
+                    self?.presenter.showCharacterListError(error)
+                }
             })
     }
     

--- a/Marvel/Source/Features/CharacterList/CharacterListInteractor.swift
+++ b/Marvel/Source/Features/CharacterList/CharacterListInteractor.swift
@@ -144,7 +144,7 @@ class CharacterListInteractor: CharacterListInteractorProtocol {
     // MARK: - Private Functions
     
     private func fetchCharacters() {
-        characterWorker.fetchCharacterList(
+        characterWorker.fetchList(
             offset: currentPage * pageCount,
             completation: { [weak self] result in
                 switch result {
@@ -157,7 +157,7 @@ class CharacterListInteractor: CharacterListInteractorProtocol {
     }
     
     private func searchForCharacter() {
-        characterWorker.fetchCharacterList(
+        characterWorker.fetchList(
             searchText: searchText,
             offset: currentPage * pageCount,
             completation: { [weak self] result in
@@ -182,7 +182,8 @@ class CharacterListInteractor: CharacterListInteractorProtocol {
     }
     
     private func searchForFavorite() {
-        let result = characterWorker.filterFavorites(byName: searchText)
+        let result = characterWorker
+            .filterFavorites(byName: searchText)
         
         switch result {
         case .success(let characters):

--- a/Marvel/Source/Persistence/Database/Realm/RealmDatabase.swift
+++ b/Marvel/Source/Persistence/Database/Realm/RealmDatabase.swift
@@ -12,7 +12,7 @@ protocol RealmDatabaseProtocol {
     
     func get<T: RealmObject>(_ key: Any) throws -> T?
     
-    func getAll<T: RealmObject>() throws -> [T]
+    func getList<T: RealmObject>() throws -> [T]
     
     func filter<T: RealmObject>(byName name: String) throws -> [T]
     
@@ -30,7 +30,7 @@ class RealmDatabase: RealmDatabaseProtocol {
         return realm.object(ofType: T.self, forPrimaryKey: key)
     }
     
-    func getAll<T: RealmObject>() throws -> [T] {
+    func getList<T: RealmObject>() throws -> [T] {
         let realm = try Realm()
         return Array(realm.objects(T.self))
     }

--- a/Marvel/Source/Persistence/PersistenceManager.swift
+++ b/Marvel/Source/Persistence/PersistenceManager.swift
@@ -10,7 +10,7 @@ import Foundation
 
 protocol PersistenceManagerProtocol {
     
-    func getAll<T: RealmObject>() -> Result<[T], MarvelError>
+    func getList<T: RealmObject>() -> Result<[T], MarvelError>
     
     func filter<T: RealmObject>(byName name: String) -> Result<[T], MarvelError>
     
@@ -33,9 +33,9 @@ class PersistenceManager: PersistenceManagerProtocol {
     
     // MARK: - Public Functions
     
-    func getAll<T: RealmObject>() -> Result<[T], MarvelError> {
+    func getList<T: RealmObject>() -> Result<[T], MarvelError> {
         do {
-            let results: [T] = try database.getAll()
+            let results: [T] = try database.getList()
             return .success(results)
             
         } catch {

--- a/Marvel/Source/Workers/Character/CharacterWorker.swift
+++ b/Marvel/Source/Workers/Character/CharacterWorker.swift
@@ -49,7 +49,7 @@ class CharacterWorker: CharacterWorkerProtocol {
             .set(offset: offset)
             .build()
         
-        request(url, completation: completation)
+        requestCharacters(url, completation: completation)
     }
     
     func fetchList(searchText: String, offset: Int, completation: @escaping CharacterCompletation) {
@@ -58,7 +58,7 @@ class CharacterWorker: CharacterWorkerProtocol {
             .set(offset: offset)
             .build()
         
-        request(url, completation: completation)
+        requestCharacters(url, completation: completation)
     }
     
     func getFavorites() -> CharacterListResult {
@@ -113,7 +113,7 @@ class CharacterWorker: CharacterWorkerProtocol {
     
     // MARK: - Private Functions
     
-    private func request(_ url: String, completation: @escaping CharacterCompletation) {
+    private func requestCharacters(_ url: String, completation: @escaping CharacterCompletation) {
         let decoder = DefaultDecoder(for: CharacterListResponse.self)
         let request = NetworkRequest(url: url, method: .get, encoding: .JSON)
         

--- a/Marvel/Source/Workers/Character/CharacterWorker.swift
+++ b/Marvel/Source/Workers/Character/CharacterWorker.swift
@@ -63,7 +63,7 @@ class CharacterWorker: CharacterWorkerProtocol {
     
     func getFavorites() -> CharacterListResult {
         let result: Result<[CharacterRealm], MarvelError>
-        result = persistenceManager.getAll()
+        result = persistenceManager.getList()
         
         switch result {
         case .success(let objects):

--- a/Marvel/Source/Workers/Character/CharacterWorker.swift
+++ b/Marvel/Source/Workers/Character/CharacterWorker.swift
@@ -22,9 +22,9 @@ protocol CharacterWorkerProtocol {
     
     func filterFavorites(byName name: String) -> CharacterListResult
     
-    func fetchCharacterList(offset: Int, completation: @escaping CharacterCompletation)
+    func fetchList(offset: Int, completation: @escaping CharacterCompletation)
     
-    func fetchCharacterList(searchText: String, offset: Int, completation: @escaping CharacterCompletation)
+    func fetchList(searchText: String, offset: Int, completation: @escaping CharacterCompletation)
 }
 
 class CharacterWorker: CharacterWorkerProtocol {
@@ -44,41 +44,21 @@ class CharacterWorker: CharacterWorkerProtocol {
     
     // MARK: - Public Functions
     
-    func fetchCharacterList(offset: Int, completation: @escaping CharacterCompletation) {
+    func fetchList(offset: Int, completation: @escaping CharacterCompletation) {
         let url = MarvelURLBuilder(resource: .characters)
             .set(offset: offset)
             .build()
         
-        let decoder = DefaultDecoder(for: CharacterListResponse.self)
-        let request = NetworkRequest(url: url, method: .get, encoding: .JSON)
-        
-        networkManager.request(request, decoder: decoder) { result in
-            switch result {
-            case .success(let response):
-                completation(.success(response))
-            case .failure(let error):
-                completation(.failure(error))
-            }
-        }
+        request(url, completation: completation)
     }
     
-    func fetchCharacterList(searchText: String, offset: Int, completation: @escaping CharacterCompletation) {
+    func fetchList(searchText: String, offset: Int, completation: @escaping CharacterCompletation) {
         let url = MarvelURLBuilder(resource: .characters)
             .set(nameStartsWith: searchText)
             .set(offset: offset)
             .build()
         
-        let decoder = DefaultDecoder(for: CharacterListResponse.self)
-        let request = NetworkRequest(url: url, method: .get, encoding: .JSON)
-        
-        networkManager.request(request, decoder: decoder) { result in
-            switch result {
-            case .success(let response):
-                completation(.success(response))
-            case .failure(let error):
-                completation(.failure(error))
-            }
-        }
+        request(url, completation: completation)
     }
     
     func getFavorites() -> CharacterListResult {
@@ -132,6 +112,20 @@ class CharacterWorker: CharacterWorkerProtocol {
     }
     
     // MARK: - Private Functions
+    
+    private func request(_ url: String, completation: @escaping CharacterCompletation) {
+        let decoder = DefaultDecoder(for: CharacterListResponse.self)
+        let request = NetworkRequest(url: url, method: .get, encoding: .JSON)
+        
+        networkManager.request(request, decoder: decoder) { result in
+            switch result {
+            case .success(let response):
+                completation(.success(response))
+            case .failure(let error):
+                completation(.failure(error))
+            }
+        }
+    }
     
     private func build(_ characters: [CharacterRealm]) -> [Character] {
         characters.map { character in

--- a/Marvel/Source/Workers/ComicBook/ComicBookWorker.swift
+++ b/Marvel/Source/Workers/ComicBook/ComicBookWorker.swift
@@ -10,7 +10,7 @@ typealias ComicBookCompletation = (Result<ComicBookListResponse?, MarvelError>) 
 
 protocol ComicBookWorkerProtocol {
     
-    func fetchComicBookList(character: Int, completation: @escaping ComicBookCompletation)
+    func fetchList(character: Int, completation: @escaping ComicBookCompletation)
 }
 
 class ComicBookWorker: ComicBookWorkerProtocol {
@@ -27,7 +27,7 @@ class ComicBookWorker: ComicBookWorkerProtocol {
     
     // MARK: - Public Functions
     
-    func fetchComicBookList(character: Int, completation: @escaping ComicBookCompletation) {
+    func fetchList(character: Int, completation: @escaping ComicBookCompletation) {
         let url = MarvelURLBuilder(resource: .comics)
             .set(characters: character)
             .build()

--- a/Marvel/Source/Workers/ComicBook/ComicBookWorker.swift
+++ b/Marvel/Source/Workers/ComicBook/ComicBookWorker.swift
@@ -6,14 +6,11 @@
 //  Copyright © 2020 Ruan Reis. All rights reserved.
 //
 
-typealias ComicBookWorkerSuccess = (_ response: ComicBookListResponse?) -> Void
-typealias ComicBookWorkerError = (_ error: MarvelError) -> Void
+typealias ComicBookCompletation = (Result<ComicBookListResponse?, MarvelError>) -> Void
 
 protocol ComicBookWorkerProtocol {
     
-    func fetchComicBookList(character: Int,
-                            sucess: @escaping ComicBookWorkerSuccess,
-                            failure: @escaping ComicBookWorkerError)
+    func fetchComicBookList(character: Int, completation: @escaping ComicBookCompletation)
 }
 
 class ComicBookWorker: ComicBookWorkerProtocol {
@@ -30,10 +27,7 @@ class ComicBookWorker: ComicBookWorkerProtocol {
     
     // MARK: - Public Functions
     
-    func fetchComicBookList(character: Int,
-                            sucess: @escaping ComicBookWorkerSuccess,
-                            failure: @escaping ComicBookWorkerError) {
-        
+    func fetchComicBookList(character: Int, completation: @escaping ComicBookCompletation) {
         let url = MarvelURLBuilder(resource: .comics)
             .set(characters: character)
             .build()
@@ -41,14 +35,13 @@ class ComicBookWorker: ComicBookWorkerProtocol {
         let decoder = DefaultDecoder(for: ComicBookListResponse.self)
         let request = NetworkRequest(url: url, method: .get, encoding: .JSON)
         
-        networkManager.request(
-            data: request,
-            decoder: decoder,
-            success: { response in
-                sucess(response)
-            },
-            failure: { error in
-                failure(error)
-            })
+        networkManager.request(request, decoder: decoder) { result in
+            switch result {
+            case .success(let response):
+                completation(.success(response))
+            case .failure(let error):
+                completation(.failure(error))
+            }
+        }
     }
 }

--- a/MarvelTests/Source/Features/CharacterDetails/CharacterDetailsSpec.swift
+++ b/MarvelTests/Source/Features/CharacterDetails/CharacterDetailsSpec.swift
@@ -30,8 +30,8 @@ class CharacterDetailsSpec: QuickSpec {
                 beforeEach {
                     viewController = CharacterDetailsBuilderMock().build(
                         character: character,
-                        characterListWorker: CharacterListWorkerSuccessMock(),
-                        comickBookListWorker: ComicBookListWorkerSucessMock())
+                        characterListWorker: CharacterWorkerSuccessMock(),
+                        comickBookListWorker: ComicBookWorkerSucessMock())
                 }
                 
                 it("View is presenting the comics that the characters participated") {
@@ -55,8 +55,8 @@ class CharacterDetailsSpec: QuickSpec {
                 beforeEach {
                     viewController = CharacterDetailsBuilderMock().build(
                         character: character,
-                        characterListWorker: CharacterListWorkerSuccessMock(),
-                        comickBookListWorker: ComicBookListWorkerSucessMock())
+                        characterListWorker: CharacterWorkerSuccessMock(),
+                        comickBookListWorker: ComicBookWorkerSucessMock())
                 }
                 
                 it("It is possible to save and delete a character as favorite") {
@@ -73,8 +73,8 @@ class CharacterDetailsSpec: QuickSpec {
                 beforeEach {
                     viewController = CharacterDetailsBuilderMock().build(
                         character: character,
-                        characterListWorker: CharacterListWorkerFailureMock(),
-                        comickBookListWorker: ComicBookListWorkerFailureMock())
+                        characterListWorker: CharacterWorkerFailureMock(),
+                        comickBookListWorker: ComicBookWorkerFailureMock())
                 }
                 
                 it("View is presenting the comics that the characters participated") {

--- a/MarvelTests/Source/Features/CharacterList/CharacterLisSpec.swift
+++ b/MarvelTests/Source/Features/CharacterList/CharacterLisSpec.swift
@@ -23,7 +23,7 @@ class CharacterLisSpec: QuickSpec {
                 
                 beforeEach {
                     viewController = CharacterListBuilderMock()
-                        .build(characterWorker: CharacterListWorkerSuccessMock())
+                        .build(characterWorker: CharacterWorkerSuccessMock())
                 }
                 
                 it("View is presenting character list from first page") {
@@ -85,7 +85,7 @@ class CharacterLisSpec: QuickSpec {
                 
                 beforeEach {
                     viewController = CharacterListBuilderMock()
-                        .build(characterWorker: CharacterListWorkerSuccessMock())
+                        .build(characterWorker: CharacterWorkerSuccessMock())
                 }
                 
                 it("The user gets his favorite characters and can also delete them") {
@@ -133,7 +133,7 @@ class CharacterLisSpec: QuickSpec {
                 
                 beforeEach {
                     viewController = CharacterListBuilderMock()
-                        .build(characterWorker: CharacterListWorkerSuccessMock())
+                        .build(characterWorker: CharacterWorkerSuccessMock())
                 }
                 
                 it("The user searches for a character by name from API") {
@@ -199,7 +199,7 @@ class CharacterLisSpec: QuickSpec {
                 
                 beforeEach {
                     viewController = CharacterListBuilderMock()
-                        .build(characterWorker: CharacterListWorkerFailureMock())
+                        .build(characterWorker: CharacterWorkerFailureMock())
                 }
                 
                 it("View is presenting error alert when fetching characters") {

--- a/MarvelTests/Source/Workers/CharacterList/Mocks/CharacterListWorkerMock.swift
+++ b/MarvelTests/Source/Workers/CharacterList/Mocks/CharacterListWorkerMock.swift
@@ -35,9 +35,7 @@ class CharacterListWorkerSuccessMock: CharacterWorkerProtocol {
         return .success(results)
     }
     
-    func fetchCharacterList(offset: Int,
-                            sucess: @escaping CharacterWorkerSuccess,
-                            failure: @escaping CharacterWorkerError) {
+    func fetchCharacterList(offset: Int, completation: @escaping CharacterCompletation) {
         do {
             let data = FileReader.read(self, resource: "CharacterList")
             var response = try JSONDecoder().decode(
@@ -54,15 +52,13 @@ class CharacterListWorkerSuccessMock: CharacterWorkerProtocol {
             response.data.total = total
             response.data.count = results.count
             response.data.results = results
-            sucess(response)
+            completation(.success(response))
         } catch {
-            failure(.networkError)
+            completation(.failure(.networkError))
         }
     }
     
-    func fetchCharacterList(searchText: String, offset: Int,
-                            sucess: @escaping CharacterWorkerSuccess,
-                            failure: @escaping CharacterWorkerError) {
+    func fetchCharacterList(searchText: String, offset: Int, completation: @escaping CharacterCompletation) {
         do {
             let data = FileReader.read(self, resource: "CharacterSearch")
             var response = try JSONDecoder().decode(
@@ -79,9 +75,9 @@ class CharacterListWorkerSuccessMock: CharacterWorkerProtocol {
             response.data.total = total
             response.data.count = results.count
             response.data.results = results
-            sucess(response)
+            completation(.success(response))
         } catch {
-            failure(.networkError)
+            completation(.failure(.networkError))
         }
     }
 }
@@ -104,15 +100,11 @@ class CharacterListWorkerFailureMock: CharacterWorkerProtocol {
         return .failure(.databaseError)
     }
     
-    func fetchCharacterList(offset: Int,
-                            sucess: @escaping CharacterWorkerSuccess,
-                            failure: @escaping CharacterWorkerError) {
-        failure(.networkError)
+    func fetchCharacterList(offset: Int, completation: @escaping CharacterCompletation) {
+        completation(.failure(.networkError))
     }
     
-    func fetchCharacterList(searchText: String, offset: Int,
-                            sucess: @escaping CharacterWorkerSuccess,
-                            failure: @escaping CharacterWorkerError) {
-        failure(.networkError)
+    func fetchCharacterList(searchText: String, offset: Int, completation: @escaping CharacterCompletation) {
+        completation(.failure(.networkError))
     }
 }

--- a/MarvelTests/Source/Workers/CharacterList/Mocks/CharacterWorkerMock.swift
+++ b/MarvelTests/Source/Workers/CharacterList/Mocks/CharacterWorkerMock.swift
@@ -1,5 +1,5 @@
 //
-//  CharacterListWorkerMock.swift
+//  CharacterWorkerMock.swift
 //  MarvelTests
 //
 //  Created by Ruan Reis on 05/08/20.
@@ -9,7 +9,7 @@
 import Foundation
 @testable import Marvel
 
-class CharacterListWorkerSuccessMock: CharacterWorkerProtocol {
+class CharacterWorkerSuccessMock: CharacterWorkerProtocol {
     
     private var favoriteCharacters: [Character] = []
     
@@ -35,7 +35,7 @@ class CharacterListWorkerSuccessMock: CharacterWorkerProtocol {
         return .success(results)
     }
     
-    func fetchCharacterList(offset: Int, completation: @escaping CharacterCompletation) {
+    func fetchList(offset: Int, completation: @escaping CharacterCompletation) {
         do {
             let data = FileReader.read(self, resource: "CharacterList")
             var response = try JSONDecoder().decode(
@@ -58,7 +58,7 @@ class CharacterListWorkerSuccessMock: CharacterWorkerProtocol {
         }
     }
     
-    func fetchCharacterList(searchText: String, offset: Int, completation: @escaping CharacterCompletation) {
+    func fetchList(searchText: String, offset: Int, completation: @escaping CharacterCompletation) {
         do {
             let data = FileReader.read(self, resource: "CharacterSearch")
             var response = try JSONDecoder().decode(
@@ -82,7 +82,7 @@ class CharacterListWorkerSuccessMock: CharacterWorkerProtocol {
     }
 }
 
-class CharacterListWorkerFailureMock: CharacterWorkerProtocol {
+class CharacterWorkerFailureMock: CharacterWorkerProtocol {
     
     func getFavorites() -> Result<[Character], MarvelError> {
         return .failure(.databaseError)
@@ -100,11 +100,11 @@ class CharacterListWorkerFailureMock: CharacterWorkerProtocol {
         return .failure(.databaseError)
     }
     
-    func fetchCharacterList(offset: Int, completation: @escaping CharacterCompletation) {
+    func fetchList(offset: Int, completation: @escaping CharacterCompletation) {
         completation(.failure(.networkError))
     }
     
-    func fetchCharacterList(searchText: String, offset: Int, completation: @escaping CharacterCompletation) {
+    func fetchList(searchText: String, offset: Int, completation: @escaping CharacterCompletation) {
         completation(.failure(.networkError))
     }
 }

--- a/MarvelTests/Source/Workers/ComicBookList/Mocks/ComicBookListWorkerMock.swift
+++ b/MarvelTests/Source/Workers/ComicBookList/Mocks/ComicBookListWorkerMock.swift
@@ -11,25 +11,23 @@ import Foundation
 
 class ComicBookListWorkerSucessMock: ComicBookWorkerProtocol {
     
-    func fetchComicBookList(character: Int,
-                            sucess: @escaping ComicBookWorkerSuccess,
-                            failure: @escaping ComicBookWorkerError) {
+    func fetchComicBookList(character: Int, completation: @escaping ComicBookCompletation) {
         do {
             let data = FileReader.read(self, resource: "ComicBookList")
             let response = try JSONDecoder().decode(
-                ComicBookListResponse.self, from: data ?? Data())
-            sucess(response)
+                ComicBookListResponse.self,
+                from: data ?? Data())
+            
+            completation(.success(response))
         } catch {
-            failure(.networkError)
+            completation(.failure(.networkError))
         }
     }
 }
 
 class ComicBookListWorkerFailureMock: ComicBookWorkerProtocol {
     
-    func fetchComicBookList(character: Int,
-                            sucess: @escaping ComicBookWorkerSuccess,
-                            failure: @escaping ComicBookWorkerError) {
-        failure(.networkError)
+    func fetchComicBookList(character: Int, completation: @escaping ComicBookCompletation) {
+        completation(.failure(.networkError))
     }
 }

--- a/MarvelTests/Source/Workers/ComicBookList/Mocks/ComicBookWorkerMock.swift
+++ b/MarvelTests/Source/Workers/ComicBookList/Mocks/ComicBookWorkerMock.swift
@@ -1,5 +1,5 @@
 //
-//  ComicBookListWorkerMock.swift
+//  ComicBookWorkerMock.swift
 //  MarvelTests
 //
 //  Created by Ruan Reis on 05/08/20.
@@ -9,9 +9,9 @@
 import Foundation
 @testable import Marvel
 
-class ComicBookListWorkerSucessMock: ComicBookWorkerProtocol {
+class ComicBookWorkerSucessMock: ComicBookWorkerProtocol {
     
-    func fetchComicBookList(character: Int, completation: @escaping ComicBookCompletation) {
+    func fetchList(character: Int, completation: @escaping ComicBookCompletation) {
         do {
             let data = FileReader.read(self, resource: "ComicBookList")
             let response = try JSONDecoder().decode(
@@ -25,9 +25,9 @@ class ComicBookListWorkerSucessMock: ComicBookWorkerProtocol {
     }
 }
 
-class ComicBookListWorkerFailureMock: ComicBookWorkerProtocol {
+class ComicBookWorkerFailureMock: ComicBookWorkerProtocol {
     
-    func fetchComicBookList(character: Int, completation: @escaping ComicBookCompletation) {
+    func fetchList(character: Int, completation: @escaping ComicBookCompletation) {
         completation(.failure(.networkError))
     }
 }


### PR DESCRIPTION
- Incluindo Result<T, MarvelError> no NetworkManager.
- Refactorings.